### PR TITLE
Disabled L-2 CIS benchmarks

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,29 +20,29 @@ cis_ubuntu2204_section6: true
 cis_ubuntu2204_rule_1_1_1_1: true
 # IMPACT: Snap packages utilizes squashfs as a compressed filesystem,
 #       disabling squashfs will cause Snap packages to fail.
-cis_ubuntu2204_rule_1_1_1_2: true
+cis_ubuntu2204_rule_1_1_1_2: false #L-2
 # IMPACT: Microsoft Azure requires the usage of udf.
-cis_ubuntu2204_rule_1_1_1_3: true
+cis_ubuntu2204_rule_1_1_1_3: false #L-2
 cis_ubuntu2204_rule_1_1_2_1: true
 cis_ubuntu2204_rule_1_1_2_2: true
 cis_ubuntu2204_rule_1_1_2_3: true
 cis_ubuntu2204_rule_1_1_2_4: true
-cis_ubuntu2204_rule_1_1_3_1: false # NOTE: not implemented full, separate partition not created
+cis_ubuntu2204_rule_1_1_3_1: false # NOTE: not implemented full, separate partition not created #L-2
 cis_ubuntu2204_rule_1_1_3_2: true
 cis_ubuntu2204_rule_1_1_3_3: true
-cis_ubuntu2204_rule_1_1_4_1: false # NOTE: not implemented full, separate partition not created
+cis_ubuntu2204_rule_1_1_4_1: false # NOTE: not implemented full, separate partition not created #L-2
 cis_ubuntu2204_rule_1_1_4_2: true
 cis_ubuntu2204_rule_1_1_4_3: true
 cis_ubuntu2204_rule_1_1_4_4: true
-cis_ubuntu2204_rule_1_1_5_1: false # NOTE: not implemented full, separate partition not created
+cis_ubuntu2204_rule_1_1_5_1: false # NOTE: not implemented full, separate partition not created #L-2
 cis_ubuntu2204_rule_1_1_5_2: true
 cis_ubuntu2204_rule_1_1_5_3: true
 cis_ubuntu2204_rule_1_1_5_4: true
-cis_ubuntu2204_rule_1_1_6_1: false # NOTE: not implemented full, separate partition not created
+cis_ubuntu2204_rule_1_1_6_1: false # NOTE: not implemented full, separate partition not created #L-2
 cis_ubuntu2204_rule_1_1_6_2: true
 cis_ubuntu2204_rule_1_1_6_3: true
 cis_ubuntu2204_rule_1_1_6_4: true
-cis_ubuntu2204_rule_1_1_7_1: false # NOTE: not implemented full, separate partition not created
+cis_ubuntu2204_rule_1_1_7_1: false # NOTE: not implemented full, separate partition not created #L-2
 cis_ubuntu2204_rule_1_1_7_2: true
 cis_ubuntu2204_rule_1_1_7_3: true
 cis_ubuntu2204_rule_1_1_8_1: true
@@ -57,21 +57,21 @@ cis_ubuntu2204_rule_1_3_2: true # NOTE: depends also on 'cis_ubuntu2204_config_a
 cis_ubuntu2204_rule_1_4_1: false # NOTE: depends also on 'cis_ubuntu2204_set_boot_pass'
 cis_ubuntu2204_rule_1_4_2: true
 cis_ubuntu2204_rule_1_4_3: false
-cis_ubuntu2204_rule_1_5_1: true
+cis_ubuntu2204_rule_1_5_1: false #L-2
 cis_ubuntu2204_rule_1_5_2: true
 cis_ubuntu2204_rule_1_5_3: true
 cis_ubuntu2204_rule_1_5_4: true
 cis_ubuntu2204_rule_1_6_1_1: true
 cis_ubuntu2204_rule_1_6_1_2: true
 cis_ubuntu2204_rule_1_6_1_3: false
-cis_ubuntu2204_rule_1_6_1_4: false
+cis_ubuntu2204_rule_1_6_1_4: false #L-2
 cis_ubuntu2204_rule_1_7_1: true
 cis_ubuntu2204_rule_1_7_2: true
 cis_ubuntu2204_rule_1_7_3: true
 cis_ubuntu2204_rule_1_7_4: true
 cis_ubuntu2204_rule_1_7_5: true
 cis_ubuntu2204_rule_1_7_6: true
-cis_ubuntu2204_rule_1_8_1: true
+cis_ubuntu2204_rule_1_8_1: false #L-2
 cis_ubuntu2204_rule_1_8_2: true # NOTE: depends also on 'cis_ubuntu2204_allow_gdm_gui'
 cis_ubuntu2204_rule_1_8_3: true # NOTE: depends also on 'cis_ubuntu2204_allow_gdm_gui'
 cis_ubuntu2204_rule_1_8_4: true # NOTE: depends also on 'cis_ubuntu2204_allow_gdm_gui'
@@ -130,10 +130,10 @@ cis_ubuntu2204_rule_3_3_6: true
 cis_ubuntu2204_rule_3_3_7: true
 cis_ubuntu2204_rule_3_3_8: true
 cis_ubuntu2204_rule_3_3_9: true
-cis_ubuntu2204_rule_3_4_1: true
-cis_ubuntu2204_rule_3_4_2: true
-cis_ubuntu2204_rule_3_4_3: true
-cis_ubuntu2204_rule_3_4_4: true
+cis_ubuntu2204_rule_3_4_1: false #L-2
+cis_ubuntu2204_rule_3_4_2: false #L-2
+cis_ubuntu2204_rule_3_4_3: false #L-2
+cis_ubuntu2204_rule_3_4_4: false #L-2
 cis_ubuntu2204_rule_3_5_1_1: true # NOTE: 'cis_ubuntu2204_firewall == ufw'
 cis_ubuntu2204_rule_3_5_1_2: true # NOTE: 'cis_ubuntu2204_firewall == ufw'
 cis_ubuntu2204_rule_3_5_1_3: true # NOTE: 'cis_ubuntu2204_firewall == ufw'
@@ -163,34 +163,34 @@ cis_ubuntu2204_rule_3_5_3_3_2: true # NOTE: 'cis_ubuntu2204_firewall == iptables
 cis_ubuntu2204_rule_3_5_3_3_3: true # NOTE: 'cis_ubuntu2204_firewall == iptables'
 cis_ubuntu2204_rule_3_5_3_3_4: true # NOTE: 'cis_ubuntu2204_firewall == iptables'
 ## SECTION 4 rules
-cis_ubuntu2204_rule_4_1_1_1: true
-cis_ubuntu2204_rule_4_1_1_2: true
-cis_ubuntu2204_rule_4_1_1_3: true
-cis_ubuntu2204_rule_4_1_1_4: true
-cis_ubuntu2204_rule_4_1_2_1: true
-cis_ubuntu2204_rule_4_1_2_2: true
-cis_ubuntu2204_rule_4_1_2_3: true
-cis_ubuntu2204_rule_4_1_3_1: true
-cis_ubuntu2204_rule_4_1_3_2: true
-cis_ubuntu2204_rule_4_1_3_3: true
-cis_ubuntu2204_rule_4_1_3_4: true
-cis_ubuntu2204_rule_4_1_3_5: true
-cis_ubuntu2204_rule_4_1_3_6: true
-cis_ubuntu2204_rule_4_1_3_7: true
-cis_ubuntu2204_rule_4_1_3_8: true
-cis_ubuntu2204_rule_4_1_3_9: true
-cis_ubuntu2204_rule_4_1_3_10: true
-cis_ubuntu2204_rule_4_1_3_11: true
-cis_ubuntu2204_rule_4_1_3_12: true
-cis_ubuntu2204_rule_4_1_3_13: true
-cis_ubuntu2204_rule_4_1_3_14: true
-cis_ubuntu2204_rule_4_1_3_15: true
-cis_ubuntu2204_rule_4_1_3_16: true
-cis_ubuntu2204_rule_4_1_3_17: true
-cis_ubuntu2204_rule_4_1_3_18: true
-cis_ubuntu2204_rule_4_1_3_19: true
-cis_ubuntu2204_rule_4_1_3_20: true
-cis_ubuntu2204_rule_4_1_3_21: true
+cis_ubuntu2204_rule_4_1_1_1: false #L-2
+cis_ubuntu2204_rule_4_1_1_2: false #L-2
+cis_ubuntu2204_rule_4_1_1_3: false #L-2
+cis_ubuntu2204_rule_4_1_1_4: false #L-2
+cis_ubuntu2204_rule_4_1_2_1: false #L-2
+cis_ubuntu2204_rule_4_1_2_2: false #L-2
+cis_ubuntu2204_rule_4_1_2_3: false #L-2
+cis_ubuntu2204_rule_4_1_3_1: false #L-2
+cis_ubuntu2204_rule_4_1_3_2: false #L-2
+cis_ubuntu2204_rule_4_1_3_3: false #L-2
+cis_ubuntu2204_rule_4_1_3_4: false #L-2
+cis_ubuntu2204_rule_4_1_3_5: false #L-2
+cis_ubuntu2204_rule_4_1_3_6: false #L-2
+cis_ubuntu2204_rule_4_1_3_7: false #L-2
+cis_ubuntu2204_rule_4_1_3_8: false #L-2
+cis_ubuntu2204_rule_4_1_3_9: false #L-2
+cis_ubuntu2204_rule_4_1_3_10: false #L-2
+cis_ubuntu2204_rule_4_1_3_11: false #L-2
+cis_ubuntu2204_rule_4_1_3_12: false #L-2
+cis_ubuntu2204_rule_4_1_3_13: false #L-2
+cis_ubuntu2204_rule_4_1_3_14: false #L-2
+cis_ubuntu2204_rule_4_1_3_15: false #L-2
+cis_ubuntu2204_rule_4_1_3_16: false #L-2
+cis_ubuntu2204_rule_4_1_3_17: false #L-2
+cis_ubuntu2204_rule_4_1_3_18: false #L-2
+cis_ubuntu2204_rule_4_1_3_19: false #L-2
+cis_ubuntu2204_rule_4_1_3_20: false #L-2
+cis_ubuntu2204_rule_4_1_3_21: false #L-2
 cis_ubuntu2204_rule_4_1_4_1: true
 cis_ubuntu2204_rule_4_1_4_2: true
 cis_ubuntu2204_rule_4_1_4_3: true
@@ -245,18 +245,18 @@ cis_ubuntu2204_rule_5_2_12: true
 cis_ubuntu2204_rule_5_2_13: true
 cis_ubuntu2204_rule_5_2_14: true
 cis_ubuntu2204_rule_5_2_15: true
-cis_ubuntu2204_rule_5_2_16: true
+cis_ubuntu2204_rule_5_2_16: false #L-2
 cis_ubuntu2204_rule_5_2_17: true
 cis_ubuntu2204_rule_5_2_18: true
 cis_ubuntu2204_rule_5_2_19: true
 cis_ubuntu2204_rule_5_2_20: true
 cis_ubuntu2204_rule_5_2_21: true
 cis_ubuntu2204_rule_5_2_22: true
-cis_ubuntu2204_rule_5_2_23: true # NOTE: own added, not included in CIS
+cis_ubuntu2204_rule_5_2_23: false # NOTE: own added, not included in CIS
 cis_ubuntu2204_rule_5_3_1: true
 cis_ubuntu2204_rule_5_3_2: true
 cis_ubuntu2204_rule_5_3_3: true
-cis_ubuntu2204_rule_5_3_4: true
+cis_ubuntu2204_rule_5_3_4: false #L-2
 cis_ubuntu2204_rule_5_3_5: true
 cis_ubuntu2204_rule_5_3_6: true
 cis_ubuntu2204_rule_5_3_7: true


### PR DESCRIPTION
# Description
This repository is intended to implement L1 CIS benchmarks only. Hence I have disabled L2 CIS benchmarks. 